### PR TITLE
Adding matchers to help stubbing the search and transport requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.5 - 2023-11-17
+* Replacing the `stub_esse_search` by a new `esse_expect_search` matcher that cover all transport actions
+
 ## 0.0.4 - 2023-11-15
 * The `cluster_id` argument of `stub_esse_search` is useless when the given index is a Esse::Index. Cluster id is now optional.
-
 
 ## 0.0.3 - 2023-11-15
 It should not automatically require `esse/rspec` anymore. You should require it manually in your `spec_helper.rb` file.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse-rspec (0.0.4)
+    esse-rspec (0.0.5)
       esse (>= 0.2.4)
       rspec (>= 3)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Stub a search request to an index with a non 200 response
 ```ruby
 allow(ProductsIndex).to esse_receive_request(:search)
   .with(body: {query: {match_all: {}}, size: 10})
-  .with_status(500, {"error" => 'Something went wrong'})
+  .and_raise_http_status(500, {"error" => 'Something went wrong'})
 ```
 
 Stub a cluster search request

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Stub a search request to an index with a non 200 response
 allow(ProductsIndex).to esse_receive_request(:search)
   .with(body: {query: {match_all: {}}, size: 10})
   .and_raise_http_status(500, {"error" => 'Something went wrong'})
+
+begin
+  ProductsIndex.search(query: {match_all: {}}, size: 10).response
+rescue Esse::Transport::InternalServerError => e
+  puts e.message # => {"error" => 'Something went wrong'}
+end
 ```
 
 Stub a cluster search request

--- a/README.md
+++ b/README.md
@@ -26,6 +26,49 @@ Require the `esse/rspec` file in your `spec_helper.rb` file:
 require 'esse/rspec'
 ```
 
+## Mock Requests
+
+Stub a search request to specific index and return a response
+
+```ruby
+allow(ProductsIndex).to esse_receive_request(:search)
+  .with(body: {query: {match_all: {}}, size: 10})
+  .and_return('hits' => { 'total' => 0, 'hits' => [] })
+
+query = ProductsIndex.search(query: {match_all: {}}, size: 10)
+query.response.total # => 0
+```
+
+Stub a search request to an index with a non 200 response
+
+```ruby
+allow(ProductsIndex).to esse_receive_request(:search)
+  .with(body: {query: {match_all: {}}, size: 10})
+  .with_status(500, {"error" => 'Something went wrong'})
+```
+
+Stub a cluster search request
+
+```ruby
+
+allow(Esse.cluster(:default)).to esse_receive_request(:search)
+  .with(index: 'geos_*', body: {query: {match_all: {}}, size: 10})
+  .and_return('hits' => { 'total' => 0, 'hits' => [] })
+
+query = Esse.cluster(:default).search('geos_*', body: {query: {match_all: {}}, size: 10})
+query.response.total # => 0
+```
+
+Stub a api/transport request
+
+```ruby
+allow(Esse.cluster).to esse_receive_request(:get)
+  .with(id: '1', index: 'products')
+  .and_return('_id' => '1', '_source' => {title: 'Product 1'})
+
+Esse.cluster.api.get('1', index: 'products') # => { '_id' => '1', '_source' => {title: 'Product 1'} }
+```
+
 ### Stubbing Esse::Index classes
 
 ```ruby
@@ -40,27 +83,5 @@ end
 it 'defines the ProductsIndex class' do
   expect(ProductsIndex).to be < Esse::Index
   expect(ProductsIndex::Product).to be < Esse::Index::Repository
-end
-```
-
-### Stubbing search requests
-
-```ruby
-before do
-  stub_esse_search(:default, "geos_*", body: {query: {match_all: {}}, size: 10}) do
-    {
-      "hits" => {
-        "total" => {
-          "value" => 1000
-        },
-        "hits" => [{}] * 20
-      }
-    }
-  end
-end
-
-it 'returns a Query using the stubbed response' do
-  query = ProductsIndex.search('geos_*', body: {query: {match_all: {}}, size: 10})
-  expect(query.responsee.total).to eq(1000)
 end
 ```

--- a/lib/esse/rspec.rb
+++ b/lib/esse/rspec.rb
@@ -4,6 +4,7 @@ require "esse"
 
 require_relative "rspec/version"
 require_relative "rspec/class_methods"
+require_relative "rspec/matchers"
 
 module Esse
   module RSpec
@@ -13,5 +14,6 @@ end
 if defined?(::RSpec)
   ::RSpec.configure do |config|
     config.include Esse::RSpec::ClassMethods
+    config.include Esse::RSpec::Matchers
   end
 end

--- a/lib/esse/rspec/matchers.rb
+++ b/lib/esse/rspec/matchers.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+module Esse
+  module RSpec
+    module Matchers
+
+      class EsseReceiveRequest
+        include ::RSpec::Matchers::Composable
+
+        STATUS_ERRORS = {
+          300 => Esse::Transport::MultipleChoicesError,
+          301 => Esse::Transport::MovedPermanentlyError,
+          302 => Esse::Transport::FoundError,
+          303 => Esse::Transport::SeeOtherError,
+          304 => Esse::Transport::NotModifiedError,
+          305 => Esse::Transport::UseProxyError,
+          307 => Esse::Transport::TemporaryRedirectError,
+          308 => Esse::Transport::PermanentRedirectError,
+          400 => Esse::Transport::BadRequestError,
+          401 => Esse::Transport::UnauthorizedError,
+          402 => Esse::Transport::PaymentRequiredError,
+          403 => Esse::Transport::ForbiddenError,
+          404 => Esse::Transport::NotFoundError,
+          405 => Esse::Transport::MethodNotAllowedError,
+          406 => Esse::Transport::NotAcceptableError,
+          407 => Esse::Transport::ProxyAuthenticationRequiredError,
+          408 => Esse::Transport::RequestTimeoutError,
+          409 => Esse::Transport::ConflictError,
+          410 => Esse::Transport::GoneError,
+          411 => Esse::Transport::LengthRequiredError,
+          412 => Esse::Transport::PreconditionFailedError,
+          413 => Esse::Transport::RequestEntityTooLargeError,
+          414 => Esse::Transport::RequestURITooLongError,
+          415 => Esse::Transport::UnsupportedMediaTypeError,
+          416 => Esse::Transport::RequestedRangeNotSatisfiableError,
+          417 => Esse::Transport::ExpectationFailedError,
+          418 => Esse::Transport::ImATeapotError,
+          421 => Esse::Transport::TooManyConnectionsFromThisIPError,
+          426 => Esse::Transport::UpgradeRequiredError,
+          450 => Esse::Transport::BlockedByWindowsParentalControlsError,
+          494 => Esse::Transport::RequestHeaderTooLargeError,
+          497 => Esse::Transport::HTTPToHTTPSError,
+          499 => Esse::Transport::ClientClosedRequestError,
+          500 => Esse::Transport::InternalServerError,
+          501 => Esse::Transport::NotImplementedError,
+          502 => Esse::Transport::BadGatewayError,
+          503 => Esse::Transport::ServiceUnavailableError,
+          504 => Esse::Transport::GatewayTimeoutError,
+          505 => Esse::Transport::HTTPVersionNotSupportedError,
+          506 => Esse::Transport::VariantAlsoNegotiatesError,
+          510 => Esse::Transport::NotExtendedError
+        }
+
+        def initialize(*args)
+          @transport_method = args.shift
+          unless Esse::Transport.instance_methods.include?(@transport_method)
+            raise ArgumentError, "expected #{@transport_method.inspect} to be a Esse::Transport method"
+          end
+
+          @definition = {}
+          if (hash = args.last).is_a?(Hash)
+            @definition.merge!(hash.transform_keys(&:to_sym))
+          end
+        end
+
+        def description
+          "esse receive request"
+        end
+
+        def matches?(index_or_cluster)
+          normalize_actual_args!(index_or_cluster)
+          allow(@cluster).to receive(:api).and_return(transport)
+          allow(transport).to receive_expected
+          receive_expected.matches?(transport)
+        end
+
+        def with(**definition)
+          @definition.update(definition)
+          self
+        end
+
+        def with_status(status, response = nil)
+          @error_class = STATUS_ERRORS[status] || Esse::Transport::ServerError
+          @response = response if response
+          self
+        end
+
+        def and_return(response)
+          @response = response
+          self
+        end
+
+        def and_raise(error_class, response = nil)
+          @error_class = error_class
+          @response = response if response
+          self
+        end
+
+        def and_call_original
+          @and_call_original = true
+          self
+        end
+
+        def exactly(times)
+          @times = times
+          self
+        end
+
+        def once
+          exactly(1)
+        end
+
+        def twice
+          exactly(2)
+        end
+
+        def at_least(times)
+          @at_least = times
+          self
+        end
+
+        def at_most(times)
+          @at_most = times
+          self
+        end
+
+        def failure_message
+          "expected that #{@cluster.id} cluster would receive `#{@transport_method}` with #{@definition}".tap do |str|
+            if @error_class
+              str << " and raise #{@error_class}"
+              str << " with #{@response}" if @response
+            elsif @response
+              str << " and return #{@response}"
+            end
+          end
+        end
+
+        def failure_message_when_negated
+          "expected that #{@cluster.id} cluster would not receive `#{@transport_method}` with #{@definition}".tap do |str|
+            if @error_class
+              str << " and raise #{@error_class}"
+              str << " with #{@response}" if @response
+            elsif @response
+              str << " and return #{@response}"
+            end
+          end
+        end
+
+        private
+
+        def transport
+          @cluster.api
+        end
+
+        def normalize_actual_args!(index_or_cluster)
+          if index_or_cluster.is_a?(Esse::Cluster)
+            @cluster = index_or_cluster
+          elsif index_or_cluster.is_a?(Class) && index_or_cluster < Esse::Index
+            @definition[:index] ||= Esse::Search::Query.normalize_indices(index_or_cluster)
+            @cluster ||= index_or_cluster.cluster
+          elsif index_or_cluster.is_a?(Symbol) || index_or_cluster.is_a?(String)
+            if Esse.config.cluster_ids.include?(index_or_cluster.to_sym)
+              @cluster = Esse.cluster(index_or_cluster)
+            end
+          end
+          raise ArgumentError, "expected #{index_or_cluster.inspect} to be an Esse::Index or Esse::Cluster" unless @cluster
+        end
+
+        def supports_block_expectations?
+          false
+        end
+
+        private
+
+        def allow(target)
+          ::RSpec::Mocks::AllowanceTarget.new(target)
+        end
+
+        def receive(method_name)
+          ::RSpec::Mocks::Matchers::Receive.new(method_name, nil)
+        end
+
+        def receive_expected
+          @receive_expected ||= begin
+            matcher = receive(@transport_method).with(**@definition)
+            matcher = matcher.and_return(@response) if defined?(@response)
+            matcher = matcher.and_raise(*[@error_class, @response].compact) if @error_class
+            matcher = matcher.and_call_original if defined?(@and_call_original)
+            if @times
+              matcher = matcher.exactly(@times).times
+            elsif @at_least
+              matcher = matcher.at_least(@at_least).times
+            elsif @at_most
+              matcher = matcher.at_most(@at_most).times
+            end
+            matcher
+          end
+        end
+      end
+
+      def esse_receive_request(*args)
+        EsseReceiveRequest.new(*args)
+      end
+      alias_method :receive_esse_request, :esse_receive_request
+    end
+  end
+end

--- a/lib/esse/rspec/matchers.rb
+++ b/lib/esse/rspec/matchers.rb
@@ -78,7 +78,7 @@ module Esse
           self
         end
 
-        def with_status(status, response = nil)
+        def and_raise_http_status(status, response = nil)
           @error_class = STATUS_ERRORS[status] || Esse::Transport::ServerError
           @response = response if response
           self

--- a/lib/esse/rspec/version.rb
+++ b/lib/esse/rspec/version.rb
@@ -2,6 +2,6 @@
 
 module Esse
   module RSpec
-    VERSION = "0.0.4"
+    VERSION = "0.0.5"
   end
 end

--- a/spec/esse/rspec/matchers/esse_receive_request_spec.rb
+++ b/spec/esse/rspec/matchers/esse_receive_request_spec.rb
@@ -42,20 +42,20 @@ require "spec_helper"
     end
   end
 
-  describe "#with_status" do
+  describe "#and_raise_http_status" do
     it "initializes @error_class with the given status" do
-      matcher = described_class.new(:search).with_status(404)
+      matcher = described_class.new(:search).and_raise_http_status(404)
       expect(matcher.instance_variable_get(:@error_class)).to eq(Esse::Transport::NotFoundError)
     end
 
     it "initializes @response with the given response" do
-      matcher = described_class.new(:search).with_status(404, "foo")
+      matcher = described_class.new(:search).and_raise_http_status(404, "foo")
       expect(matcher.instance_variable_get(:@response)).to eq("foo")
     end
 
     it "returns self" do
       matcher = described_class.new(:search)
-      expect(matcher.with_status(404)).to be(matcher)
+      expect(matcher.and_raise_http_status(404)).to be(matcher)
     end
   end
 
@@ -219,7 +219,7 @@ require "spec_helper"
       end
 
       it "raises the transport error according to the given status" do
-        expect(cluster).to esse_receive_request(:search, index: "test", q: "*").with_status(404, error_msg = {"error" => "not found"})
+        expect(cluster).to esse_receive_request(:search, index: "test", q: "*").and_raise_http_status(404, error_msg = {"error" => "not found"})
         query = cluster.search("test", q: "*")
         expect {
           query.response

--- a/spec/esse/rspec/matchers/esse_receive_request_spec.rb
+++ b/spec/esse/rspec/matchers/esse_receive_request_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+::RSpec.describe Esse::RSpec::Matchers::EsseReceiveRequest do
+  describe "initialize" do
+    it "raises an error if the argument is not a Esse::Transport method" do
+      expect {
+        described_class.new(:foo)
+      }.to raise_error(ArgumentError, "expected :foo to be a Esse::Transport method")
+    end
+
+    it "initializes @transport_method" do
+      expect(described_class.new(:search).instance_variable_get(:@transport_method)).to eq(:search)
+    end
+
+    it "initializes @definition with given args" do
+      matcher = described_class.new(:search, :foo, bar: :baz)
+      expect(matcher.instance_variable_get(:@definition)).to eq({bar: :baz})
+    end
+
+    it "symbolizes keys of the definition" do
+      matcher = described_class.new(:search, "foo", "bar" => :baz)
+      expect(matcher.instance_variable_get(:@definition)).to eq({bar: :baz})
+    end
+  end
+
+  describe "#with" do
+    it "initializes @definition with the given args" do
+      matcher = described_class.new(:search).with(foo: :bar)
+      expect(matcher.instance_variable_get(:@definition)).to eq({foo: :bar})
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.with(foo: :bar)).to be(matcher)
+    end
+
+    it "does not replace the initial definition" do
+      matcher = described_class.new(:search, foo: :bar).with(bar: :baz)
+      expect(matcher.instance_variable_get(:@definition)).to eq({foo: :bar, bar: :baz})
+    end
+  end
+
+  describe "#with_status" do
+    it "initializes @error_class with the given status" do
+      matcher = described_class.new(:search).with_status(404)
+      expect(matcher.instance_variable_get(:@error_class)).to eq(Esse::Transport::NotFoundError)
+    end
+
+    it "initializes @response with the given response" do
+      matcher = described_class.new(:search).with_status(404, "foo")
+      expect(matcher.instance_variable_get(:@response)).to eq("foo")
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.with_status(404)).to be(matcher)
+    end
+  end
+
+  describe "#and_return" do
+    it "initializes @response with the given response" do
+      matcher = described_class.new(:search).and_return("foo")
+      expect(matcher.instance_variable_get(:@response)).to eq("foo")
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.and_return("foo")).to be(matcher)
+    end
+  end
+
+  describe "#and_raise" do
+    it "initializes @error_class with the given error class" do
+      matcher = described_class.new(:search).and_raise(Esse::Transport::NotFoundError)
+      expect(matcher.instance_variable_get(:@error_class)).to eq(Esse::Transport::NotFoundError)
+    end
+
+    it "initializes @response with the given response" do
+      matcher = described_class.new(:search).and_raise(Esse::Transport::NotFoundError, "foo")
+      expect(matcher.instance_variable_get(:@response)).to eq("foo")
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.and_raise(Esse::Transport::NotFoundError)).to be(matcher)
+    end
+  end
+
+  describe "#exactly" do
+    it "initializes @times with the given number" do
+      matcher = described_class.new(:search).exactly(2)
+      expect(matcher.instance_variable_get(:@times)).to eq(2)
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.exactly(2)).to be(matcher)
+    end
+  end
+
+  describe "#once" do
+    it "initializes @times with 1" do
+      matcher = described_class.new(:search).once
+      expect(matcher.instance_variable_get(:@times)).to eq(1)
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.once).to be(matcher)
+    end
+  end
+
+  describe "#twice" do
+    it "initializes @times with 2" do
+      matcher = described_class.new(:search).twice
+      expect(matcher.instance_variable_get(:@times)).to eq(2)
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.twice).to be(matcher)
+    end
+  end
+
+  describe "#at_least" do
+    it "initializes @at_least with the given number" do
+      matcher = described_class.new(:search).at_least(2)
+      expect(matcher.instance_variable_get(:@at_least)).to eq(2)
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.at_least(2)).to be(matcher)
+    end
+  end
+
+  describe "#at_most" do
+    it "initializes @at_most with the given number" do
+      matcher = described_class.new(:search).at_most(2)
+      expect(matcher.instance_variable_get(:@at_most)).to eq(2)
+    end
+
+    it "returns self" do
+      matcher = described_class.new(:search)
+      expect(matcher.at_most(2)).to be(matcher)
+    end
+  end
+
+  describe "#setup_expectation" do
+    let(:raw_response) do
+      {
+        "hits" => {
+          "total" => {
+            "value" => 1,
+            "relation" => "eq"
+          },
+          "max_score" => 1.0,
+          "hits" => [
+            {"_index" => "test", "_type" => "_doc", "_id" => "1", "_score" => 1.0, "_source" => {"title" => "Test"}}
+          ]
+        }
+      }
+    end
+    let(:cluster) { Esse.cluster(:default) }
+
+    before do
+      stub_esse_index(:products)
+    end
+
+    it "returns a mock expectation with a cluster instance" do
+      matcher = described_class.new(:search, index: "test", q: "*").and_return(raw_response)
+      expect(matcher.matches?(cluster)).to be_an_instance_of(RSpec::Mocks::MessageExpectation)
+      cluster.search("test", q: "*").response
+    end
+
+    it "returns a mock expectation with a given index class" do
+      matcher = described_class.new(:search, index: "products", q: "*")
+      expect(matcher.matches?(ProductsIndex)).to be_an_instance_of(RSpec::Mocks::MessageExpectation)
+      ProductsIndex.search("*").response
+    end
+
+    it "returns a mock expectation with a given cluster id" do
+      matcher = described_class.new(:search, index: "test", q: "*")
+      expect(matcher.matches?(:default)).to be_an_instance_of(RSpec::Mocks::MessageExpectation)
+      Esse.cluster(:default).search("test", q: "*").response
+    end
+
+    it "raises an error if the cluster is not found" do
+      matcher = described_class.new(:search, index: "test", q: "*")
+      expect {
+        matcher.matches?(:foo)
+      }.to raise_error(ArgumentError, "expected :foo to be an Esse::Index or Esse::Cluster")
+    end
+
+    context "when stubbing :api method" do
+      let(:raw_response) do
+        {"_id" => 1, "_source" => {"title" => "Test"}}
+      end
+
+      it "returns the mocked response" do
+        expect(cluster).to esse_receive_request(:get, index: "test", id: 1).and_return(raw_response)
+        expect(cluster.api.get(index: "test", id: 1)).to eq(raw_response)
+      end
+    end
+
+    context "with rspec matcher" do
+      it "returns the mocked response" do
+        expect(cluster).to esse_receive_request(:search, index: "test", q: "*").and_return(raw_response)
+        expect(resp = cluster.search("test", q: "*").response).to be_an_instance_of(Esse::Search::Response)
+        expect(resp.raw_response).to eq(raw_response)
+      end
+
+      it "returns the mocked response with a given index class" do
+        expect(ProductsIndex).to esse_receive_request(:search, index: "products", q: "*").and_return(raw_response)
+        expect(resp = ProductsIndex.search("*").response).to be_an_instance_of(Esse::Search::Response)
+        expect(resp.raw_response).to eq(raw_response)
+      end
+
+      it "raises the transport error according to the given status" do
+        expect(cluster).to esse_receive_request(:search, index: "test", q: "*").with_status(404, error_msg = {"error" => "not found"})
+        query = cluster.search("test", q: "*")
+        expect {
+          query.response
+        }.to raise_error { |error|
+          error.is_a?(Esse::Transport::NotFoundError) && error.message == error_msg
+        }
+      end
+
+      it "mocks the transport but calls the real method" do
+        expect(cluster).to esse_receive_request(:search, index: "test", q: "*").and_call_original
+        expect {
+          cluster.search("test", q: "*").response
+        }.to raise_error(Esse::Error).with_message(/is not defined/)
+      end
+
+      it "mocks the transport but calls the real method with a given index class" do
+        expect(ProductsIndex).to esse_receive_request(:search, index: "products", q: "*").and_call_original
+        expect {
+          ProductsIndex.search("*").response
+        }.to raise_error(Esse::Error).with_message(/is not defined/)
+      end
+
+      it "allows to receive the request twice" do
+        expect(cluster).to esse_receive_request(:search, index: "test", q: "*").twice.and_return(raw_response)
+        expect(cluster.search("test", q: "*").response).to be_an_instance_of(Esse::Search::Response)
+        expect(cluster.search("test", q: "*").response).to be_an_instance_of(Esse::Search::Response)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Mock Requests

Stub a search request to specific index and return a response

```ruby
expect(ProductsIndex).to esse_receive_request(:search)
  .with(body: {query: {match_all: {}}, size: 10})
  .and_return('hits' => { 'total' => 0, 'hits' => [] })

query = ProductsIndex.search(query: {match_all: {}}, size: 10)
query.response.total # => 0
```

Stub a search request to an index with a non 200 response

```ruby
expect(ProductsIndex).to esse_receive_request(:search)
  .with(body: {query: {match_all: {}}, size: 10})
  .and_raise_http_status(500, {"error" => 'Something went wrong'})

begin
  ProductsIndex.search(query: {match_all: {}}, size: 10).response
rescue Esse::Transport::InternalServerError => e
  puts e.message # => {"error" => 'Something went wrong'}
end
```

Stub a cluster search request

```ruby

expect(Esse.cluster(:default)).to esse_receive_request(:search)
  .with(index: 'geos_*', body: {query: {match_all: {}}, size: 10})
  .and_return('hits' => { 'total' => 0, 'hits' => [] })

query = Esse.cluster(:default).search('geos_*', body: {query: {match_all: {}}, size: 10})
query.response.total # => 0
```

Stub a api/transport request

```ruby
expect(Esse.cluster).to esse_receive_request(:get)
  .with(id: '1', index: 'products')
  .and_return('_id' => '1', '_source' => {title: 'Product 1'})

Esse.cluster.api.get('1', index: 'products') # => { '_id' => '1', '_source' => {title: 'Product 1'} }
```